### PR TITLE
When playlist has several streams show selection dialog to the user

### DIFF
--- a/app/src/main/java/org/y20k/transistor/helpers/StationFetcher.java
+++ b/app/src/main/java/org/y20k/transistor/helpers/StationFetcher.java
@@ -156,7 +156,9 @@ public final class StationFetcher extends AsyncTask<Void, Void, Bundle> implemen
             }
 
             // show error dialog
-            DialogError.show(mActivity, errorTitle, errorMessage, errorDetails);
+            if (!fetchResults.getBoolean(RESULT_USER_CANCELLED, false)) {
+                DialogError.show(mActivity, errorTitle, errorMessage, errorDetails);
+            }
         }
 
     }

--- a/app/src/main/java/org/y20k/transistor/helpers/TransistorKeys.java
+++ b/app/src/main/java/org/y20k/transistor/helpers/TransistorKeys.java
@@ -59,6 +59,7 @@ public interface TransistorKeys {
 
     /* RESULTS */
     String RESULT_FETCH_ERROR = "FETCH_ERROR";
+    String RESULT_USER_CANCELLED = "USER_CANCELLED";
     String RESULT_PLAYLIST_TYPE = "PLAYLIST_TYPE";
     String RESULT_STREAM_TYPE = "STREAM_TYPE";
     String RESULT_FILE_CONTENT = "FILE_CONTENT";

--- a/app/src/main/res/layout/listview_select_station.xml
+++ b/app/src/main/res/layout/listview_select_station.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/select_station_name"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/descr_station_name"
+        android:text="@string/descr_station_name_example"
+        android:textAppearance="@android:style/TextAppearance.Material.Medium"
+        android:textColor="?android:attr/textColorPrimary"
+        android:layout_marginTop="5dp"
+        android:layout_marginLeft="5dp"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/select_station_uri"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/descr_player_sheet_p_stream_url"
+        android:text="@string/descr_player_sheet_p_stream_url"
+        android:textColor="?android:attr/textColorPrimary"
+        android:layout_marginBottom="5dp"
+        android:layout_marginLeft="5dp"
+        app:layout_constraintTop_toBottomOf="@+id/select_station_name" />
+
+</android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
Almost all radio stations have several streams in the playlist, usually mirrors, but sometimes with different bitrate or codec. The worst abuser is this station, which has separate stream with different music in the same playlist: https://dnbradio.com/hi.pls
This patch will show a simple popup dialog with all stations from the playlist, and user can select one.

One bug that I've noticed is adding two streams from the same playlist makes Transistor save them into the same file on disk, so the next time it starts, it loses one stream from the station list. But this can be reproduced even without the patch, if two different radio stations have a playlist file named 'listen.pls' for example, it will be overwritten if you add both.