### PR TITLE
Implement MediaBrowserServiceCompat.onSkipTo<Previous|Next>

### DIFF
--- a/app/src/main/java/org/y20k/transistor/PlayerService.java
+++ b/app/src/main/java/org/y20k/transistor/PlayerService.java
@@ -934,14 +934,36 @@ public final class PlayerService extends MediaBrowserServiceCompat implements Tr
 
         @Override
         public void onSkipToNext() {
+            LogHelper.d(LOG_TAG, "onSkipToNext");
             super.onSkipToNext();
-            // handle requests to skip to the next media item // todo implement
+            if (mStation == null) {
+                return;
+            }
+            MediaMetadataCompat station = mStationListProvider.getStationAfter(mStation.getStationId());
+            if (station == null) {
+                station = mStationListProvider.getFirstStation();
+            }
+            if (station != null) {
+                mStation = new Station(station);
+                startPlayback();
+            }
         }
 
         @Override
         public void onSkipToPrevious() {
+            LogHelper.d(LOG_TAG, "onSkipToPrevious");
             super.onSkipToPrevious();
-            // handle requests to skip to the previous media item // todo implement
+            if (mStation == null) {
+                return;
+            }
+            MediaMetadataCompat station = mStationListProvider.getStationBefore(mStation.getStationId());
+            if (station == null) {
+                station = mStationListProvider.getLastStation();
+            }
+            if (station != null) {
+                mStation = new Station(station);
+                startPlayback();
+            }
         }
 
     }

--- a/app/src/main/java/org/y20k/transistor/core/Station.java
+++ b/app/src/main/java/org/y20k/transistor/core/Station.java
@@ -812,6 +812,12 @@ public final class Station implements TransistorKeys, Cloneable, Comparable<Stat
     }
 
 
+    /* Getter for station id */
+    public String getStationId() {
+        // since we don't have a unique ID, we fake one using the hashcode of the stream address
+        return String.valueOf(this.getStreamUri().hashCode());
+    }
+
     /* Getter for URL of stream */
     public Uri getStreamUri() {
         return mStreamUri;


### PR DESCRIPTION
This implements the skip to previous / skip to next behaviour for the media browser service; this is useful for interacting with hardware forward/back buttons (e.g. for Android Auto).

I'm afraid that I don't really know what I'm doing / my way around Java, so there's probably dumb things that needs to be looked at.  For example, I'm switching to a `TreeMap` instead of a `LinkedHashMap` so I can actually iterate from one element to the next; but that changes the sort order so it's no longer the order they were created in.

To test: install [android-media-controller](https://github.com/googlesamples/android-media-controller) and use that to control transistor.  While there _is_ a [desktop head unit](https://developer.android.com/training/auto/testing/) for Android Auto, I couldn't figure out how to make that emulate previous/next buttons.

Thanks for writing transistor, and hopefully we can evolve this into something mergable!

Fixes #89