### PR TITLE
Fix crash when loading malformed images

### DIFF
--- a/app/src/main/java/org/y20k/transistor/helpers/ImageHelper.java
+++ b/app/src/main/java/org/y20k/transistor/helpers/ImageHelper.java
@@ -43,7 +43,7 @@ public final class ImageHelper {
 
 
     /* Main class variables */
-    private static Bitmap mInputImage;
+    private static Bitmap mInputImage = null;
     private final Context mContext;
 
 
@@ -53,7 +53,8 @@ public final class ImageHelper {
         if (station != null && station.getStationImageFile() != null && station.getStationImageFile().exists()) {
             // get station image
             mInputImage = decodeSampledBitmapFromFile(station.getStationImageFile().toString(), 72, 72);
-        } else {
+        }
+        if (mInputImage == null) {
             // set default station image
             mInputImage = getBitmap(R.drawable.ic_music_note_black_36dp);
         }


### PR DESCRIPTION
If the station image in the filesystem is invalid, loading it via BitmapFactory will return null, and attempting to construct a Palette will cause an exception to be thrown and the app to crash.

This fixes that by using the default music note image in those cases.