### PR TITLE
Reduce collection data about 50% than before, becuase station-image-s…

### DIFF
--- a/app/src/main/java/org/y20k/transistor/Keys.kt
+++ b/app/src/main/java/org/y20k/transistor/Keys.kt
@@ -166,7 +166,6 @@ object Keys {
     // file names and extensions
     const val COLLECTION_FILE: String = "collection.json"
     const val STATION_IMAGE_FILE: String = "station-image.jpg"
-    const val STATION_SMALL_IMAGE_FILE: String = "station-image-small.jpg"
     const val DEBUG_LOG_FILE: String = "log-can-be-deleted.txt"
     const val TRANSISTOR_LEGACY_STATION_FILE_EXTENSION: String = ".m3u"
 

--- a/app/src/main/java/org/y20k/transistor/helpers/CollectionHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/CollectionHelper.kt
@@ -194,7 +194,7 @@ object CollectionHelper {
         collection.stations.forEach { station ->
             // compare image location protocol-agnostic (= without http / https)
             if (station.remoteImageLocation.substringAfter(":") == remoteFileLocation.substringAfter(":")) {
-                station.smallImage = FileHelper.saveStationImage(context, station.uuid, tempImageFileUri.toString(), Keys.SIZE_STATION_IMAGE_CARD, Keys.STATION_SMALL_IMAGE_FILE).toString()
+                station.smallImage = FileHelper.saveStationImage(context, station.uuid, tempImageFileUri.toString(), Keys.SIZE_STATION_IMAGE_CARD, Keys.STATION_IMAGE_FILE).toString()
                 station.image = FileHelper.saveStationImage(context, station.uuid, tempImageFileUri, Keys.SIZE_STATION_IMAGE_MAXIMUM, Keys.STATION_IMAGE_FILE).toString()
                 station.imageColor = ImageHelper.getMainColor(context, tempImageFileUri)
                 station.imageManuallySet = imageManuallySet
@@ -211,7 +211,7 @@ object CollectionHelper {
         collection.stations.forEach { station ->
             // find stattion by uuid
             if (station.uuid == stationUuid) {
-                station.smallImage = FileHelper.saveStationImage(context, station.uuid, tempImageFileUri, Keys.SIZE_STATION_IMAGE_CARD, Keys.STATION_SMALL_IMAGE_FILE).toString()
+                station.smallImage = FileHelper.saveStationImage(context, station.uuid, tempImageFileUri, Keys.SIZE_STATION_IMAGE_CARD, Keys.STATION_IMAGE_FILE).toString()
                 station.image = FileHelper.saveStationImage(context, station.uuid, tempImageFileUri, Keys.SIZE_STATION_IMAGE_MAXIMUM, Keys.STATION_IMAGE_FILE).toString()
                 station.imageColor = ImageHelper.getMainColor(context, tempImageFileUri)
                 station.imageManuallySet = imageManuallySet

--- a/app/src/main/java/org/y20k/transistor/helpers/ImportHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/ImportHelper.kt
@@ -53,7 +53,7 @@ object ImportHelper {
                         val sourceImageUri: String = getLegacyStationImageFileUri(context, station)
                         if (sourceImageUri != Keys.LOCATION_DEFAULT_STATION_IMAGE) {
                             // create and add image and small image + get main color
-                            station.image = FileHelper.saveStationImage(context, station.uuid, sourceImageUri, Keys.SIZE_STATION_IMAGE_CARD, Keys.STATION_SMALL_IMAGE_FILE).toString()
+                            station.image = FileHelper.saveStationImage(context, station.uuid, sourceImageUri, Keys.SIZE_STATION_IMAGE_CARD, Keys.STATION_IMAGE_FILE).toString()
                             station.smallImage = FileHelper.saveStationImage(context, station.uuid, sourceImageUri, Keys.SIZE_STATION_IMAGE_MAXIMUM, Keys.STATION_IMAGE_FILE).toString()
                             station.imageColor = ImageHelper.getMainColor(context, sourceImageUri)
                             station.imageManuallySet = true


### PR DESCRIPTION
…mall.jpg is the same than station-image.jpg.

A duplicate of the image is not necessary and only costs the storage space of the device.

And it is also good/better for the performance.