### PR TITLE
Migrate to ActivityResult APIs

### DIFF
--- a/app/src/main/java/org/y20k/transistor/Keys.kt
+++ b/app/src/main/java/org/y20k/transistor/Keys.kt
@@ -194,11 +194,7 @@ object Keys {
     const val EMPTY_STRING_RESOURCE: Int = 0
 
     // requests
-    const val REQUEST_LOAD_IMAGE: Int = 1
     const val REQUEST_UPDATE_COLLECTION: Int = 2
-    const val REQUEST_SAVE_M3U: Int = 3
-    const val PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE: Int = 23
-    const val PERMISSION_REQUEST_IMAGE_PICKER_READ_EXTERNAL_STORAGE = 42
 
     // results
     const val RESULT_DATA_SLEEP_TIMER_REMAINING: String = "DATA_SLEEP_TIMER_REMAINING"


### PR DESCRIPTION
As of Fragment [1.3.0](https://developer.android.com/jetpack/androidx/releases/fragment#1.3.0) (which AppCompat 1.3.0 uses internally), we can now use the ActivityResult APIs.
