### PR TITLE
Refactor and optimize PreferencesHelper

### DIFF
--- a/app/src/main/java/org/y20k/transistor/MainActivity.kt
+++ b/app/src/main/java/org/y20k/transistor/MainActivity.kt
@@ -14,7 +14,6 @@
 
 package org.y20k.transistor
 
-import android.content.Context
 import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -23,7 +22,6 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.navigateUp
-import androidx.preference.PreferenceManager
 import org.y20k.transistor.helpers.AppThemeHelper
 import org.y20k.transistor.helpers.FileHelper
 import org.y20k.transistor.helpers.LogHelper
@@ -63,7 +61,7 @@ class MainActivity: AppCompatActivity() {
         supportActionBar?.hide()
 
         // register listener for changes in shared preferences
-        PreferenceManager.getDefaultSharedPreferences(this as Context).registerOnSharedPreferenceChangeListener(sharedPreferenceChangeListener)
+        PreferencesHelper.registerPreferenceChangeListener(sharedPreferenceChangeListener)
     }
 
 
@@ -80,7 +78,7 @@ class MainActivity: AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         // unregister listener for changes in shared preferences
-        PreferenceManager.getDefaultSharedPreferences(this as Context).unregisterOnSharedPreferenceChangeListener(sharedPreferenceChangeListener)
+        PreferencesHelper.unregisterPreferenceChangeListener(sharedPreferenceChangeListener)
     }
 
 
@@ -90,7 +88,7 @@ class MainActivity: AppCompatActivity() {
     private val sharedPreferenceChangeListener = SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
         when (key) {
             Keys.PREF_THEME_SELECTION -> {
-                AppThemeHelper.setTheme(PreferencesHelper.loadThemeSelection(this@MainActivity))
+                AppThemeHelper.setTheme(PreferencesHelper.loadThemeSelection())
             }
         }
     }

--- a/app/src/main/java/org/y20k/transistor/PlayerFragment.kt
+++ b/app/src/main/java/org/y20k/transistor/PlayerFragment.kt
@@ -125,9 +125,9 @@ class PlayerFragment: Fragment(), CoroutineScope,
         initializeViews()
 
         // convert old stations (one-time import)
-        if (PreferencesHelper.isHouseKeepingNecessary(activity as Context)) {
+        if (PreferencesHelper.isHouseKeepingNecessary()) {
             if (ImportHelper.convertOldStations(activity as Context)) layout.toggleImportingStationViews()
-            PreferencesHelper.saveHouseKeepingNecessaryState(activity as Context)
+            PreferencesHelper.saveHouseKeepingNecessaryState()
         }
 
         // hide action bar
@@ -171,14 +171,14 @@ class PlayerFragment: Fragment(), CoroutineScope,
         // assign volume buttons to music volume
         activity?.volumeControlStream = AudioManager.STREAM_MUSIC
         // try to recreate player state
-        playerState = PreferencesHelper.loadPlayerState(activity as Context)
+        playerState = PreferencesHelper.loadPlayerState()
         // setup ui
         setupPlayer()
         setupList()
         // start watching for changes in shared preferences
-        PreferencesHelper.registerPreferenceChangeListener(activity as Context, this as SharedPreferences.OnSharedPreferenceChangeListener)
+        PreferencesHelper.registerPreferenceChangeListener(this as SharedPreferences.OnSharedPreferenceChangeListener)
         // toggle download progress indicator
-        layout.toggleDownloadProgressIndicator(activity as Context)
+        layout.toggleDownloadProgressIndicator()
     }
 
 
@@ -186,11 +186,11 @@ class PlayerFragment: Fragment(), CoroutineScope,
     override fun onPause() {
         super.onPause()
         // save player state
-        PreferencesHelper.savePlayerState(activity as Context, playerState)
+        PreferencesHelper.savePlayerState(playerState)
         // stop receiving playback progress updates
         handler.removeCallbacks(periodicProgressUpdateRequestRunnable)
         // stop watching for changes in shared preferences
-        PreferencesHelper.unregisterPreferenceChangeListener(activity as Context, this as SharedPreferences.OnSharedPreferenceChangeListener)
+        PreferencesHelper.unregisterPreferenceChangeListener(this as SharedPreferences.OnSharedPreferenceChangeListener)
 
     }
 
@@ -245,7 +245,7 @@ class PlayerFragment: Fragment(), CoroutineScope,
     /* Overrides onSharedPreferenceChanged from OnSharedPreferenceChangeListener */
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, key: String?) {
         if (key == Keys.PREF_ACTIVE_DOWNLOADS) {
-            layout.toggleDownloadProgressIndicator(activity as Context)
+            layout.toggleDownloadProgressIndicator()
         }
     }
 
@@ -394,7 +394,7 @@ class PlayerFragment: Fragment(), CoroutineScope,
     private fun buildPlaybackControls() {
 
         // get player state
-        playerState = PreferencesHelper.loadPlayerState(activity as Context)
+        playerState = PreferencesHelper.loadPlayerState()
 
         // main play/pause button
         layout.playButtonView.setOnClickListener {
@@ -531,7 +531,7 @@ class PlayerFragment: Fragment(), CoroutineScope,
             // update collection
             collection = it
             // updates current station in player views
-            playerState = PreferencesHelper.loadPlayerState(activity as Context)
+            playerState = PreferencesHelper.loadPlayerState()
             // toggle onboarding layout
             onboarding = layout.toggleOnboarding(activity as Context, collection.stations.size)
             // get station

--- a/app/src/main/java/org/y20k/transistor/Transistor.kt
+++ b/app/src/main/java/org/y20k/transistor/Transistor.kt
@@ -18,6 +18,7 @@ import android.app.Application
 import org.y20k.transistor.helpers.AppThemeHelper
 import org.y20k.transistor.helpers.LogHelper
 import org.y20k.transistor.helpers.PreferencesHelper
+import org.y20k.transistor.helpers.PreferencesHelper.initPreferences
 
 
 /**
@@ -33,8 +34,9 @@ class Transistor: Application () {
     override fun onCreate() {
         super.onCreate()
         LogHelper.v(TAG, "Transistor application started.")
+        initPreferences()
         // set Dark / Light theme state
-        AppThemeHelper.setTheme(PreferencesHelper.loadThemeSelection(this))
+        AppThemeHelper.setTheme(PreferencesHelper.loadThemeSelection())
     }
 
 

--- a/app/src/main/java/org/y20k/transistor/dialogs/FindStationDialog.kt
+++ b/app/src/main/java/org/y20k/transistor/dialogs/FindStationDialog.kt
@@ -93,7 +93,7 @@ class FindStationDialog (private var context: Context, private var listener: Fin
     /* Construct and show dialog */
     fun show() {
         // initialize a radio browser search
-        radioBrowserSearch = RadioBrowserSearch(context, this)
+        radioBrowserSearch = RadioBrowserSearch(this)
 
         // prepare dialog builder
         val builder: MaterialAlertDialogBuilder = MaterialAlertDialogBuilder(context)

--- a/app/src/main/java/org/y20k/transistor/helpers/AppThemeHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/AppThemeHelper.kt
@@ -74,7 +74,7 @@ object AppThemeHelper {
 
     /* Returns a readable String for currently selected App Theme */
     fun getCurrentTheme(context: Context): String {
-        return when (PreferencesHelper.loadThemeSelection(context)) {
+        return when (PreferencesHelper.loadThemeSelection()) {
             Keys.STATE_THEME_LIGHT_MODE -> context.getString(R.string.pref_theme_selection_mode_light)
             Keys.STATE_THEME_DARK_MODE -> context.getString(R.string.pref_theme_selection_mode_dark)
             else -> context.getString(R.string.pref_theme_selection_mode_device_default)

--- a/app/src/main/java/org/y20k/transistor/helpers/CollectionHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/CollectionHelper.kt
@@ -65,17 +65,17 @@ object CollectionHelper {
 
 
     /* Checks if enough time passed since last update */
-    fun hasEnoughTimePassedSinceLastUpdate(context: Context): Boolean {
-        val lastUpdate: Date = PreferencesHelper.loadLastUpdateCollection(context)
+    fun hasEnoughTimePassedSinceLastUpdate(): Boolean {
+        val lastUpdate: Date = PreferencesHelper.loadLastUpdateCollection()
         val currentDate: Date = Calendar.getInstance().time
         return currentDate.time - lastUpdate.time  > Keys.MINIMUM_TIME_BETWEEN_UPDATES
     }
 
 
     /* Checks if a newer collection of radio stations is available on storage */
-    fun isNewerCollectionAvailable(context: Context, date: Date): Boolean {
+    fun isNewerCollectionAvailable(date: Date): Boolean {
         var newerCollectionAvailable = false
-        val modificationDate: Date = PreferencesHelper.loadCollectionModificationDate(context)
+        val modificationDate: Date = PreferencesHelper.loadCollectionModificationDate()
         if (modificationDate.after(date) || date == Keys.DEFAULT_DATE) {
             newerCollectionAvailable = true
         }
@@ -348,7 +348,7 @@ object CollectionHelper {
         // save collection and store modification date
         collection.modificationDate = saveCollection(context, collection)
         // save playback state of PlayerService
-        PreferencesHelper.savePlayerPlaybackState(context, playbackState)
+        PreferencesHelper.savePlayerPlaybackState(playbackState)
         return collection
     }
 

--- a/app/src/main/java/org/y20k/transistor/helpers/DownloadWorker.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/DownloadWorker.kt
@@ -52,11 +52,11 @@ class DownloadWorker(context : Context, params : WorkerParameters): Worker(conte
 
     /* Execute one-time housekeeping */
     private fun doOneTimeHousekeeping() {
-        if (PreferencesHelper.isHouseKeepingNecessary(applicationContext)) {
+        if (PreferencesHelper.isHouseKeepingNecessary()) {
             /* add whatever housekeeping is necessary here */
 
             // housekeeping finished - save state
-            // PreferencesHelper.saveHouseKeepingNecessaryState(applicationContext) // TODO uncomment if you need to do housekeeping here
+            // PreferencesHelper.saveHouseKeepingNecessaryState() // TODO uncomment if you need to do housekeeping here
         }
     }
 

--- a/app/src/main/java/org/y20k/transistor/helpers/FileHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/FileHelper.kt
@@ -184,7 +184,7 @@ object FileHelper {
         LogHelper.v(TAG, "Saving collection - Thread: ${Thread.currentThread().name}")
         val collectionSize: Int = collection.stations.size
         // do not override an existing collection with an empty one - except when last station is deleted
-        if (collectionSize > 0 || PreferencesHelper.loadCollectionSize(context) == 1) {
+        if (collectionSize > 0 || PreferencesHelper.loadCollectionSize() == 1) {
             // convert to JSON
             val gson: Gson = getCustomGson()
             var json: String = String()
@@ -197,8 +197,8 @@ object FileHelper {
                 // write text file
                 writeTextFile(context, json, Keys.FOLDER_COLLECTION, Keys.COLLECTION_FILE)
                 // save modification date and collection size
-                PreferencesHelper.saveCollectionModificationDate(context, lastSave)
-                PreferencesHelper.saveCollectionSize(context, collectionSize)
+                PreferencesHelper.saveCollectionModificationDate(lastSave)
+                PreferencesHelper.saveCollectionSize(collectionSize)
             } else {
                 LogHelper.w(TAG, "Not writing collection file. Reason: JSON string was completely empty.")
             }

--- a/app/src/main/java/org/y20k/transistor/helpers/LogHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/LogHelper.kt
@@ -80,7 +80,7 @@ object LogHelper {
     }
 
     fun save(context: Context, tag: String, t: Throwable?, vararg messages: Any) {
-        if (PreferencesHelper.loadKeepDebugLog(context)) {
+        if (PreferencesHelper.loadKeepDebugLog()) {
             val sb = StringBuilder()
             sb.append(DateTimeHelper.convertToRfc2822(Calendar.getInstance().time))
             sb.append(" | ")

--- a/app/src/main/java/org/y20k/transistor/helpers/NetworkHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/NetworkHelper.kt
@@ -143,7 +143,7 @@ object NetworkHelper {
 
 
     /* Suspend function: Gets a random radio-browser.info api address - async using coroutine */
-    suspend fun getRadioBrowserServerSuspended(context: Context): String {
+    suspend fun getRadioBrowserServerSuspended(): String {
         return suspendCoroutine { cont ->
             var serverAddress: String
             try {
@@ -154,7 +154,7 @@ object NetworkHelper {
             } catch (e: UnknownHostException) {
                 serverAddress = Keys.RADIO_BROWSER_API_DEFAULT
             }
-            PreferencesHelper.saveRadioBrowserApiAddress(context, serverAddress)
+            PreferencesHelper.saveRadioBrowserApiAddress(serverAddress)
             cont.resume(serverAddress)
         }
     }

--- a/app/src/main/java/org/y20k/transistor/helpers/PreferencesHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/PreferencesHelper.kt
@@ -31,158 +31,148 @@ import java.util.*
  */
 object PreferencesHelper {
 
+    /* The sharedPreferences object to be initialized */
+    private lateinit var sharedPreferences: SharedPreferences
+
+    /* Initialize a single sharedPreferences object when the app is launched */
+    fun Context.initPreferences() {
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
+    }
+
     /* Define log tag */
     private val TAG: String = LogHelper.makeLogTag(PreferencesHelper::class.java)
 
 
     /* Loads address of radio-browser.info API from shared preferences */
-    fun loadRadioBrowserApiAddress(context: Context): String {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getString(Keys.PREF_RADIO_BROWSER_API, Keys.RADIO_BROWSER_API_DEFAULT) ?: Keys.RADIO_BROWSER_API_DEFAULT
+    fun loadRadioBrowserApiAddress(): String {
+        return sharedPreferences.getString(Keys.PREF_RADIO_BROWSER_API, Keys.RADIO_BROWSER_API_DEFAULT) ?: Keys.RADIO_BROWSER_API_DEFAULT
     }
 
 
     /* Saves address of radio-browser.info API to shared preferences */
-    fun saveRadioBrowserApiAddress(context: Context, radioBrowserApi: String) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveRadioBrowserApiAddress(radioBrowserApi: String) {
+        sharedPreferences.edit {
             putString(Keys.PREF_RADIO_BROWSER_API, radioBrowserApi)
         }
     }
 
 
     /* Loads keepDebugLog true or false */
-    fun loadKeepDebugLog(context: Context): Boolean {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getBoolean(Keys.PREF_KEEP_DEBUG_LOG, false)
+    fun loadKeepDebugLog(): Boolean {
+        return sharedPreferences.getBoolean(Keys.PREF_KEEP_DEBUG_LOG, false)
     }
 
 
     /* Saves keepDebugLog true or false */
-    fun saveKeepDebugLog(context: Context, keepDebugLog: Boolean = false) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveKeepDebugLog(keepDebugLog: Boolean = false) {
+        sharedPreferences.edit {
             putBoolean(Keys.PREF_KEEP_DEBUG_LOG, keepDebugLog)
         }
     }
 
 
     /* Loads state of playback for player / PlayerService from shared preferences */
-    fun loadPlayerPlaybackState(context: Context): Int {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getInt(Keys.PREF_CURRENT_PLAYBACK_STATE, PlaybackStateCompat.STATE_STOPPED)
+    fun loadPlayerPlaybackState(): Int {
+        return sharedPreferences.getInt(Keys.PREF_CURRENT_PLAYBACK_STATE, PlaybackStateCompat.STATE_STOPPED)
     }
 
 
     /* Saves state of playback for player / PlayerService to shared preferences */
-    fun savePlayerPlaybackState(context: Context, playbackState: Int) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun savePlayerPlaybackState(playbackState: Int) {
+        sharedPreferences.edit {
             putInt(Keys.PREF_CURRENT_PLAYBACK_STATE, playbackState)
         }
     }
 
 
     /* Loads state of playback for player / PlayerService from shared preferences */
-    fun loadPlayerPlaybackSpeed(context: Context): Float {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getFloat(Keys.PREF_PLAYER_STATE_PLAYBACK_SPEED, 1f)
+    fun loadPlayerPlaybackSpeed(): Float {
+        return sharedPreferences.getFloat(Keys.PREF_PLAYER_STATE_PLAYBACK_SPEED, 1f)
     }
 
 
     /* Saves state of playback for player / PlayerService to shared preferences */
-    fun savePlayerPlaybackSpeed(context: Context, playbackSpeed: Float) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun savePlayerPlaybackSpeed(playbackSpeed: Float) {
+        sharedPreferences.edit {
             putFloat(Keys.PREF_PLAYER_STATE_PLAYBACK_SPEED, playbackSpeed)
         }
     }
 
 
     /* Loads last update from shared preferences */
-    fun loadLastUpdateCollection(context: Context): Date {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        val lastSaveString: String = settings.getString(Keys.PREF_LAST_UPDATE_COLLECTION, "") ?: String()
+    fun loadLastUpdateCollection(): Date {
+        val lastSaveString: String = sharedPreferences.getString(Keys.PREF_LAST_UPDATE_COLLECTION, "") ?: String()
         return DateTimeHelper.convertFromRfc2822(lastSaveString)
     }
 
 
     /* Saves last update to shared preferences */
-    fun saveLastUpdateCollection(context: Context, lastUpdate: Date = Calendar.getInstance().time) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveLastUpdateCollection(lastUpdate: Date = Calendar.getInstance().time) {
+        sharedPreferences.edit {
             putString(Keys.PREF_LAST_UPDATE_COLLECTION, DateTimeHelper.convertToRfc2822(lastUpdate))
         }
     }
 
 
     /* Loads size of collection from shared preferences */
-    fun loadCollectionSize(context: Context): Int {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getInt(Keys.PREF_COLLECTION_SIZE, -1)
+    fun loadCollectionSize(): Int {
+        return sharedPreferences.getInt(Keys.PREF_COLLECTION_SIZE, -1)
     }
 
 
     /* Saves site of collection to shared preferences */
-    fun saveCollectionSize(context: Context, size: Int) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveCollectionSize(size: Int) {
+        sharedPreferences.edit {
             putInt(Keys.PREF_COLLECTION_SIZE, size)
         }
     }
 
 
     /* Loads date of last save operation from shared preferences */
-    fun loadCollectionModificationDate(context: Context): Date {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        val modificationDateString: String = settings.getString(Keys.PREF_COLLECTION_MODIFICATION_DATE, "") ?: String()
+    fun loadCollectionModificationDate(): Date {
+        val modificationDateString: String = sharedPreferences.getString(Keys.PREF_COLLECTION_MODIFICATION_DATE, "") ?: String()
         return DateTimeHelper.convertFromRfc2822(modificationDateString)
     }
 
 
     /* Saves date of last save operation to shared preferences */
-    fun saveCollectionModificationDate(context: Context, lastSave: Date = Calendar.getInstance().time) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveCollectionModificationDate(lastSave: Date = Calendar.getInstance().time) {
+        sharedPreferences.edit {
             putString(Keys.PREF_COLLECTION_MODIFICATION_DATE, DateTimeHelper.convertToRfc2822(lastSave))
         }
     }
 
 
     /* Loads active downloads from shared preferences */
-    fun loadActiveDownloads(context: Context): String {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        val activeDownloadsString: String = settings.getString(Keys.PREF_ACTIVE_DOWNLOADS, Keys.ACTIVE_DOWNLOADS_EMPTY) ?: Keys.ACTIVE_DOWNLOADS_EMPTY
+    fun loadActiveDownloads(): String {
+        val activeDownloadsString: String = sharedPreferences.getString(Keys.PREF_ACTIVE_DOWNLOADS, Keys.ACTIVE_DOWNLOADS_EMPTY) ?: Keys.ACTIVE_DOWNLOADS_EMPTY
         LogHelper.v(TAG, "IDs of active downloads: $activeDownloadsString")
         return activeDownloadsString
     }
 
 
     /* Saves active downloads to shared preferences */
-    fun saveActiveDownloads(context: Context, activeDownloadsString: String = String()) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveActiveDownloads(activeDownloadsString: String = String()) {
+        sharedPreferences.edit {
             putString(Keys.PREF_ACTIVE_DOWNLOADS, activeDownloadsString)
         }
     }
 
 
     /* Loads state of player user interface from shared preferences */
-    fun loadPlayerState(context: Context): PlayerState {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        val playerState: PlayerState = PlayerState()
-        playerState.stationUuid = settings.getString(Keys.PREF_PLAYER_STATE_STATION_UUID, String()) ?: String()
-        playerState.playbackState = settings.getInt(Keys.PREF_PLAYER_STATE_PLAYBACK_STATE, PlaybackStateCompat.STATE_STOPPED)
-        playerState.bottomSheetState = settings.getInt(Keys.PREF_PLAYER_STATE_BOTTOM_SHEET_STATE, BottomSheetBehavior.STATE_HIDDEN)
-        playerState.sleepTimerState = settings.getInt(Keys.PREF_PLAYER_STATE_SLEEP_TIMER_STATE, Keys.STATE_SLEEP_TIMER_STOPPED)
-        return playerState
+    fun loadPlayerState(): PlayerState {
+        return PlayerState().apply {
+            stationUuid = sharedPreferences.getString(Keys.PREF_PLAYER_STATE_STATION_UUID, String()) ?: String()
+            playbackState = sharedPreferences.getInt(Keys.PREF_PLAYER_STATE_PLAYBACK_STATE, PlaybackStateCompat.STATE_STOPPED)
+            bottomSheetState = sharedPreferences.getInt(Keys.PREF_PLAYER_STATE_BOTTOM_SHEET_STATE, BottomSheetBehavior.STATE_HIDDEN)
+            sleepTimerState = sharedPreferences.getInt(Keys.PREF_PLAYER_STATE_SLEEP_TIMER_STATE, Keys.STATE_SLEEP_TIMER_STOPPED)
+        }
     }
 
 
     /* Saves state of player user interface to shared preferences */
-    fun savePlayerState(context: Context, playerState: PlayerState) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun savePlayerState(playerState: PlayerState) {
+        sharedPreferences.edit {
             putString(Keys.PREF_PLAYER_STATE_STATION_UUID, playerState.stationUuid)
             putInt(Keys.PREF_PLAYER_STATE_PLAYBACK_STATE, playerState.playbackState)
             putInt(Keys.PREF_PLAYER_STATE_BOTTOM_SHEET_STATE, playerState.bottomSheetState)
@@ -192,27 +182,25 @@ object PreferencesHelper {
 
 
     /* Loads uuid of last played station from shared preferences */
-    fun loadLastPlayedStationUuid(context: Context): String {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getString(Keys.PREF_PLAYER_STATE_STATION_UUID, String()) ?: String()
+    fun loadLastPlayedStationUuid(): String {
+        return sharedPreferences.getString(Keys.PREF_PLAYER_STATE_STATION_UUID, String()) ?: String()
     }
 
 
     /* Saves history of metadata in shared preferences */
-    fun saveMetadataHistory(context: Context, metadataHistory: MutableList<String>) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
+    fun saveMetadataHistory(metadataHistory: MutableList<String>) {
         val gson = Gson()
         val json = gson.toJson(metadataHistory)
-        settings.edit {
+        sharedPreferences.edit {
             putString(Keys.PREF_PLAYER_METADATA_HISTORY, json)
         }
     }
 
 
     /* Loads history of metadata from shared preferences */
-    fun loadMetadataHistory(context: Context): MutableList<String> {
+    fun loadMetadataHistory(): MutableList<String> {
         var metadataHistory: MutableList<String> = mutableListOf()
-        val json: String = PreferenceManager.getDefaultSharedPreferences(context).getString(Keys.PREF_PLAYER_METADATA_HISTORY, String()) ?: String()
+        val json: String = sharedPreferences.getString(Keys.PREF_PLAYER_METADATA_HISTORY, String()) ?: String()
         if (json.isNotEmpty()) {
             val gson = Gson()
             metadataHistory = gson.fromJson(json, metadataHistory::class.java)
@@ -222,36 +210,39 @@ object PreferencesHelper {
 
 
     /* Start watching for changes in shared preferences - context must implement OnSharedPreferenceChangeListener */
-    fun registerPreferenceChangeListener(context: Context, listener: SharedPreferences.OnSharedPreferenceChangeListener) {
-        PreferenceManager.getDefaultSharedPreferences(context).registerOnSharedPreferenceChangeListener(listener)
+    fun registerPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(listener)
     }
 
 
     /* Stop watching for changes in shared preferences - context must implement OnSharedPreferenceChangeListener */
-    fun unregisterPreferenceChangeListener(context: Context, listener: SharedPreferences.OnSharedPreferenceChangeListener) {
-        PreferenceManager.getDefaultSharedPreferences(context).unregisterOnSharedPreferenceChangeListener(listener)
+    fun unregisterPreferenceChangeListener(listener: SharedPreferences.OnSharedPreferenceChangeListener) {
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(listener)
     }
 
 
     /* Checks if housekeeping work needs to be done - used usually in DownloadWorker "REQUEST_UPDATE_COLLECTION" */
-    fun isHouseKeepingNecessary(context: Context): Boolean {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        return settings.getBoolean(Keys.PREF_ONE_TIME_HOUSEKEEPING_NECESSARY, true)
+    fun isHouseKeepingNecessary(): Boolean {
+        return sharedPreferences.getBoolean(Keys.PREF_ONE_TIME_HOUSEKEEPING_NECESSARY, true)
     }
 
 
     /* Saves state of housekeeping */
-    fun saveHouseKeepingNecessaryState(context: Context, state: Boolean = false) {
-        val settings = PreferenceManager.getDefaultSharedPreferences(context)
-        settings.edit {
+    fun saveHouseKeepingNecessaryState(state: Boolean = false) {
+        sharedPreferences.edit {
             putBoolean(Keys.PREF_ONE_TIME_HOUSEKEEPING_NECESSARY, state)
         }
     }
 
 
     /* Load currently selected app theme */
-    fun loadThemeSelection(context: Context): String {
-        return PreferenceManager.getDefaultSharedPreferences(context).getString(Keys.PREF_THEME_SELECTION, Keys.STATE_THEME_FOLLOW_SYSTEM) ?: Keys.STATE_THEME_FOLLOW_SYSTEM
+    fun loadThemeSelection(): String {
+        return sharedPreferences.getString(Keys.PREF_THEME_SELECTION, Keys.STATE_THEME_FOLLOW_SYSTEM) ?: Keys.STATE_THEME_FOLLOW_SYSTEM
+    }
+
+    /* Return whether to download over mobile */
+    fun downloadOverMobile(): Boolean {
+        return sharedPreferences.getBoolean(Keys.PREF_DOWNLOAD_OVER_MOBILE, Keys.DEFAULT_DOWNLOAD_OVER_MOBILE)
     }
 
 }

--- a/app/src/main/java/org/y20k/transistor/helpers/UpdateHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/UpdateHelper.kt
@@ -79,7 +79,7 @@ class UpdateHelper(private val context: Context, private val updateHelperListene
 
     /* Updates the whole collection of stations */
     fun updateCollection() {
-        PreferencesHelper.saveLastUpdateCollection(context)
+        PreferencesHelper.saveLastUpdateCollection()
         var counter: Boolean
         collection.stations.forEach {station ->
             if (station.radioBrowserStationUuid.isNotEmpty()) {
@@ -118,7 +118,7 @@ class UpdateHelper(private val context: Context, private val updateHelperListene
 
     /* Get updated station from radio browser - results are handled by onRadioBrowserSearchResults */
     private fun downloadFromRadioBrowser(radioBrowserStationUuid: String) {
-        val radioBrowserSearch: RadioBrowserSearch = RadioBrowserSearch(context, this)
+        val radioBrowserSearch: RadioBrowserSearch = RadioBrowserSearch(this)
         radioBrowserSearch.searchStation(context, radioBrowserStationUuid, Keys.SEARCH_TYPE_BY_UUID)
     }
 

--- a/app/src/main/java/org/y20k/transistor/playback/PlayerService.kt
+++ b/app/src/main/java/org/y20k/transistor/playback/PlayerService.kt
@@ -121,16 +121,16 @@ class PlayerService(): MediaBrowserServiceCompat() {
         userAgent = Util.getUserAgent(this, Keys.APPLICATION_NAME)
 
         // load modification date of collection
-        modificationDate = PreferencesHelper.loadCollectionModificationDate(this)
+        modificationDate = PreferencesHelper.loadCollectionModificationDate()
 
         // get the package validator // todo can be local?
         packageValidator = PackageValidator(this, R.xml.allowed_media_browser_callers)
 
         // fetch the player state
-        playerState = PreferencesHelper.loadPlayerState(this)
+        playerState = PreferencesHelper.loadPlayerState()
 
         // fetch the metadata history
-        metadataHistory = PreferencesHelper.loadMetadataHistory(this)
+        metadataHistory = PreferencesHelper.loadMetadataHistory()
 
         // create a new MediaSession
         createMediaSession()
@@ -236,7 +236,7 @@ class PlayerService(): MediaBrowserServiceCompat() {
         mediaSessionConnector.invalidateMediaSessionMetadata()
         notificationHelper.updateNotification()
         // save history
-        PreferencesHelper.saveMetadataHistory(this, metadataHistory)
+        PreferencesHelper.saveMetadataHistory(metadataHistory)
     }
 
 
@@ -502,7 +502,7 @@ class PlayerService(): MediaBrowserServiceCompat() {
             playerState.stationUuid = station.uuid
         }
         playerState.playbackState = playbackState
-        PreferencesHelper.savePlayerState(this, playerState)
+        PreferencesHelper.savePlayerState(playerState)
     }
 
 
@@ -688,7 +688,7 @@ class PlayerService(): MediaBrowserServiceCompat() {
             if (station.isValid()) {
                 preparePlayer(playWhenReady)
             } else {
-                val currentStationUuid: String = PreferencesHelper.loadLastPlayedStationUuid(this@PlayerService)
+                val currentStationUuid: String = PreferencesHelper.loadLastPlayedStationUuid()
                 onPrepareFromMediaId(currentStationUuid, playWhenReady, null)
             }
         }
@@ -746,7 +746,7 @@ class PlayerService(): MediaBrowserServiceCompat() {
         override fun onCommand(player: Player, controlDispatcher: ControlDispatcher, command: String, extras: Bundle?, cb: ResultReceiver?): Boolean {
             when (command) {
                 Keys.CMD_RELOAD_PLAYER_STATE -> {
-                    playerState = PreferencesHelper.loadPlayerState(this@PlayerService)
+                    playerState = PreferencesHelper.loadPlayerState()
                     return true
                 }
                 Keys.CMD_REQUEST_PROGRESS_UPDATE -> {

--- a/app/src/main/java/org/y20k/transistor/search/RadioBrowserSearch.kt
+++ b/app/src/main/java/org/y20k/transistor/search/RadioBrowserSearch.kt
@@ -15,7 +15,7 @@ import org.y20k.transistor.helpers.LogHelper
 import org.y20k.transistor.helpers.NetworkHelper
 import org.y20k.transistor.helpers.PreferencesHelper
 
-class RadioBrowserSearch(private var context: Context, private var radioBrowserSearchListener: RadioBrowserSearchListener) {
+class RadioBrowserSearch(private var radioBrowserSearchListener: RadioBrowserSearchListener) {
 
     /* Interface used to send back search results */
     interface RadioBrowserSearchListener {
@@ -36,7 +36,7 @@ class RadioBrowserSearch(private var context: Context, private var radioBrowserS
     /* Init constructor */
     init {
         // get address of radio-browser.info api and update it in background
-        radioBrowserApi = PreferencesHelper.loadRadioBrowserApiAddress(context)
+        radioBrowserApi = PreferencesHelper.loadRadioBrowserApiAddress()
         updateRadioBrowserApi()
     }
 
@@ -103,7 +103,7 @@ class RadioBrowserSearch(private var context: Context, private var radioBrowserS
     /* Updates the address of the radio-browser.info api */
     private fun updateRadioBrowserApi() {
         GlobalScope.launch {
-            val deferred: Deferred<String> = async { NetworkHelper.getRadioBrowserServerSuspended(context) }
+            val deferred: Deferred<String> = async { NetworkHelper.getRadioBrowserServerSuspended() }
             radioBrowserApi = deferred.await()
         }
     }

--- a/app/src/main/java/org/y20k/transistor/ui/LayoutHolder.kt
+++ b/app/src/main/java/org/y20k/transistor/ui/LayoutHolder.kt
@@ -103,7 +103,7 @@ data class LayoutHolder(var rootView: View) {
         onboardingQuoteViews = rootView.findViewById(R.id.onboarding_quote_views)
         onboardingImportViews = rootView.findViewById(R.id.onboarding_import_views)
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
-        metadataHistory = PreferencesHelper.loadMetadataHistory(rootView.context)
+        metadataHistory = PreferencesHelper.loadMetadataHistory()
         metadataHistoryPosition = metadataHistory.size - 1
 
         // set up RecyclerView
@@ -253,8 +253,8 @@ data class LayoutHolder(var rootView: View) {
 
 
     /* Toggles visibility of the download progress indicator */
-    fun toggleDownloadProgressIndicator(context: Context) {
-        when (PreferencesHelper.loadActiveDownloads(context)) {
+    fun toggleDownloadProgressIndicator() {
+        when (PreferencesHelper.loadActiveDownloads()) {
             Keys.ACTIVE_DOWNLOADS_EMPTY -> downloadProgressIndicator.isGone = true
             else -> downloadProgressIndicator.isVisible = true
         }


### PR DESCRIPTION
I've refactored the PreferenceHelper to use a single sharedPreferences object [initialized on app launch](https://github.com/y20k/transistor/commit/19d1789f71cd3bbe5f3019779dcc1843be5ba253#diff-6f9501e85d43e5dd7da8fcb00ef804722de7dbdd85e6932f1d0fd8b74e8a4436R37).

Benefits:
- No more passing a bunch of unnecessary contexts around.
- No more unnecessary operations where we create a brand new `PreferenceManager.getDefaultSharedPreferences` instance any time a key needs to be accessed.
  - We now register and unregister the same sharedPreferences object too
