### PR TITLE
CollectionViewModel fixes/improvements

### DIFF
--- a/app/src/main/java/org/y20k/transistor/helpers/FileHelper.kt
+++ b/app/src/main/java/org/y20k/transistor/helpers/FileHelper.kt
@@ -25,8 +25,10 @@ import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.y20k.transistor.Keys
 import org.y20k.transistor.core.Collection
 import org.y20k.transistor.core.Station
@@ -310,11 +312,10 @@ object FileHelper {
 
 
     /* Suspend function: Wrapper for readCollection */
-    suspend fun readCollectionSuspended(context: Context): Collection {
-        return suspendCoroutine {cont ->
-            cont.resume(readCollection(context))
+    suspend fun readCollectionSuspended(context: Context): Collection =
+        withContext(Dispatchers.IO) {
+            readCollection(context)
         }
-    }
 
 
     /* Suspend function: Wrapper for copyFile */


### PR DESCRIPTION
* uiScope is not needed, viewModelScope extension is the same
* deferred collection is not needed (async {} will launch a new unnecessary coroutine)
* run readCollectionSuspended in Dispatcher.IO (the client of readCollectionSuspended shouldn't dictate which context to run this)